### PR TITLE
Fix CVEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.idea
+
+helm

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,6 @@ RUN for full_version in 1.28.3;  \
         && chmod 755 /opt/kubectl/$version/kubectl; \
      done;
 RUN ln -s /opt/kubectl/1.28 /opt/kubectl/default
+
+# Overwrite existing helm binary with one that patches [GHSA-m425-mq94-257g](https://github.com/advisories/GHSA-m425-mq94-257g)
+COPY helm /bin/helm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,18 @@
 # onbuild includes build-time logic that requires the directory to be structured as specified in:
 # https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/building-deployer-helm.md
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm/onbuild
+
+# Remove existing kubectl binaries
+RUN rm -rf /opt/kubectl
+
+# Copied from here:
+# https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/b9aeb72dfa1ae1a725691c8265911ed456c679e5/marketplace/deployer_helm_base/Dockerfile#L20
+RUN for full_version in 1.28.3;  \
+     do \
+        version=${full_version%.*} \
+        && mkdir -p /opt/kubectl/$version \
+        && wget -q -O /opt/kubectl/$version/kubectl \
+            https://storage.googleapis.com/kubernetes-release/release/v$full_version/bin/linux/amd64/kubectl \
+        && chmod 755 /opt/kubectl/$version/kubectl; \
+     done;
+RUN ln -s /opt/kubectl/1.28 /opt/kubectl/default

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ docker-build-installer:
 		-t $(INSTALLER_IMAGE_REPO):$(DEPLOYER_IMAGE_VERSION) \
 		--build-arg GLOO_VERSION=$(GLOO_VERSION) \
 		-f installer/Dockerfile \
+		--platform linux/amd64 \
 		installer
 
 .PHONY: docker-build-deployer

--- a/Makefile
+++ b/Makefile
@@ -77,4 +77,6 @@ test-install:
 test-uninstall:
 	kubectl delete namespace $(TEST_NS)
 
-
+.PHONY: patch-helm
+patch-helm:
+	./patch-helm.sh

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,15 @@ docker-build-installer:
 		installer
 
 .PHONY: docker-build-deployer
-docker-build-deployer:
+docker-build-deployer: patch-helm
 	docker build \
 		-t $(DEPLOYER_IMAGE_REPO):$(DEPLOYER_IMAGE_VERSION) \
 		-f Dockerfile \
 		. --no-cache
+
+.PHONY: patch-helm
+patch-helm:
+	./patch-helm.sh
 
 #----------------------------------------------------------------------------------
 # Publish
@@ -76,7 +80,3 @@ test-install:
 .PHONY: test-uninstall
 test-uninstall:
 	kubectl delete namespace $(TEST_NS)
-
-.PHONY: patch-helm
-patch-helm:
-	./patch-helm.sh

--- a/installer/Dockerfile
+++ b/installer/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine
 
 ARG GLOO_VERSION
-ARG KUBE_MINOR_VERSION=1.27
-ARG KUBE_PATCH_VERSION=0
+ARG KUBE_MINOR_VERSION=1.28
+ARG KUBE_PATCH_VERSION=3
 
 # install glooctl
 RUN wget https://github.com/solo-io/gloo/releases/download/v$GLOO_VERSION/glooctl-linux-amd64

--- a/patch-helm.sh
+++ b/patch-helm.sh
@@ -1,0 +1,21 @@
+#!/bin/sh -xe
+
+CUR_DIR=$(pwd)
+TEMP_DIR=$(mktemp -d)
+
+cd $TEMP_DIR
+
+git clone git@github.com:helm/helm.git
+
+cd helm
+
+# Update gRPC dependency to version where
+# [GHSA-m425-mq94-257g](https://github.com/advisories/GHSA-m425-mq94-257g) is patched
+go get google.golang.org/grpc@v1.56.3
+
+# Build the binaries for all architectures
+make build-cross
+
+# Use the linux-amd64 one as that is the architecture the deployer image is based on
+mkdir -p $CUR_DIR/helm-linux-amd64
+cp -r _dist/linux-amd64/helm $CUR_DIR/helm


### PR DESCRIPTION
## Summary 
Fixes CVEs in all the images:
- deployer:
    - CVE-2023-2253 (in kubectl)
    - CVE-2023-28840 (in helm)
    - GHSA-m425-mq94-257g (in helm)
- installer:
    - CVE-2023-2253 (in kubectl)

Helm has not fixed yet, so I added a small script to build a patched binary locally. I have verified with `mpdev verify` that this all works.

## Current state of CVEs
The only remaining CVE is GHSA-m425-mq94-257g, which needs to be fixed in `gloo` and in the `glooctl` binary.

### Deployer

```
trivy image --severity HIGH,CRITICAL gcr.io/solo-io-public/gloo/deployer:1.15.14

....

gcr.io/solo-io-public/gloo/deployer:1.15.14 (ubuntu 20.04)

Total: 0 (HIGH: 0, CRITICAL: 0)
```

### Installer

```
trivy image --severity HIGH,CRITICAL gcr.io/solo-io-public/gloo/installer:1.15.14

...

gcr.io/solo-io-public/gloo/installer:1.15.14 (alpine 3.18.4)

Total: 0 (HIGH: 0, CRITICAL: 0)


bin/glooctl (gobinary)

Total: 1 (HIGH: 1, CRITICAL: 0)

┌────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬────────────────────────┬───────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Status │ Installed Version │     Fixed Version      │                       Title                       │
├────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │ HIGH     │ fixed  │ v1.40.0           │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability          │
│                        │                     │          │        │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g │
└────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴────────────────────────┴───────────────────────────────────────────────────┘
```

### Gloo Edge

```
trivy image --severity HIGH,CRITICAL gcr.io/gloo-edge/gloo:1.15.14

...

gcr.io/gloo-edge/gloo:1.15.14 (ubuntu 20.04)

Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/gloo (gobinary)

Total: 1 (HIGH: 1, CRITICAL: 0)

┌────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬────────────────────────┬───────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │ Status │ Installed Version │     Fixed Version      │                       Title                       │
├────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-m425-mq94-257g │ HIGH     │ fixed  │ v1.40.0           │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability          │
│                        │                     │          │        │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g │
└────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴────────────────────────┴───────────────────────────────────────────────────┘
```